### PR TITLE
feat: support etag attribute on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ colored_json = "5"
 csaf = { version = "0.5.0", default-features = false }
 csv = "1"
 cyclonedx-bom = "0.8.0"
-deno_core = "0.352.0"
+deno_core = "0.353.0"
 digest = "0.10.6"
 env_logger = "0.11"
 filetime = "0.2"
 flate2 = "1"
 flexible-time = "0.1.1"
 fluent-uri = "0.3.2"
+fsquirrel = "0.1"
 futures = "0.3"
 futures-util = "0.3"
 hickory-resolver = "0.25.1"
@@ -69,7 +70,6 @@ tokio = "1"
 tracing = "0.1"
 url = "2"
 walkdir = "2.4"
-xattr = "1"
 
 # internal dependencies
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ digest = { workspace = true }
 filetime = { workspace = true }
 flexible-time = { workspace = true }
 fluent-uri = { workspace = true }
+fsquirrel = { workspace = true }
 futures-util = { workspace = true }
 html-escape = { workspace = true }
 humantime = { workspace = true }
@@ -55,10 +56,6 @@ env_logger = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 liblzma = { workspace = true, optional = true }
 sequoia-openpgp = { workspace = true, optional = true }
-
-# workaround until xattr fixes its win32 compilation issues.
-[target.'cfg(any(unix, macos))'.dependencies]
-xattr = { workspace = true }
 
 [features]
 default = ["bzip2"]

--- a/csaf/Cargo.toml
+++ b/csaf/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { workspace = true, features = ["serde"] }
 csv = { workspace = true }
 digest = { workspace = true }
 fluent-uri = { workspace = true }
+fsquirrel = { workspace = true }
 futures = { workspace = true }
 hickory-resolver = { workspace = true, features = ["tokio"] }
 html-escape = { workspace = true }
@@ -66,10 +67,6 @@ csaf-validator-lib = [
 
 # enable for semver checks (in addition to default)
 _semver = ["csaf-validator-lib"]
-
-# workaround until xattr fixes its win32 compilation issues.
-[target.'cfg(any(unix, macos))'.dependencies]
-xattr = { workspace = true }
 
 [package.metadata.cargo-all-features]
 always_include_features = [

--- a/csaf/csaf-cli/src/cmd/mod.rs
+++ b/csaf/csaf-cli/src/cmd/mod.rs
@@ -52,7 +52,6 @@ impl From<FilterArguments> for FilterConfig {
 #[command(next_help_heading = "Storage")]
 pub struct StoreArguments {
     /// Disable the use of extended attributes, e.g. for etag information.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[arg(long)]
     pub no_xattrs: bool,
 
@@ -76,7 +75,6 @@ impl TryFrom<StoreArguments> for StoreVisitor {
 
         let result = Self::new(base).no_timestamps(value.no_timestamps);
 
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let result = result.no_xattrs(value.no_xattrs);
 
         Ok(result)

--- a/csaf/src/source/file.rs
+++ b/csaf/src/source/file.rs
@@ -252,13 +252,10 @@ impl Source for FileSource {
             .and_then(|md| md.modified().ok())
             .map(OffsetDateTime::from);
 
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        let etag = xattr::get(&path, walker_common::store::ATTR_ETAG)
+        let etag = fsquirrel::get(&path, walker_common::store::ATTR_ETAG)
             .transpose()
             .and_then(|r| r.ok())
             .and_then(|s| String::from_utf8(s).ok());
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-        let etag = None;
 
         Ok(RetrievedAdvisory {
             discovered,

--- a/csaf/src/visitors/store.rs
+++ b/csaf/src/visitors/store.rs
@@ -32,7 +32,6 @@ pub struct StoreVisitor {
     pub no_timestamps: bool,
 
     /// whether to store additional metadata (like the etag) using extended attributes
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub no_xattrs: bool,
 }
 
@@ -41,7 +40,6 @@ impl StoreVisitor {
         Self {
             base: base.into(),
             no_timestamps: false,
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
             no_xattrs: false,
         }
     }
@@ -51,7 +49,6 @@ impl StoreVisitor {
         self
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn no_xattrs(mut self, no_xattrs: bool) -> Self {
         self.no_xattrs = no_xattrs;
         self
@@ -259,7 +256,6 @@ impl StoreVisitor {
                 sha512: &advisory.sha512,
                 signature: &advisory.signature,
                 no_timestamps: self.no_timestamps,
-                #[cfg(any(target_os = "linux", target_os = "macos"))]
                 no_xattrs: self.no_xattrs,
             },
         )

--- a/sbom/src/visitors/store.rs
+++ b/sbom/src/visitors/store.rs
@@ -31,7 +31,6 @@ pub struct StoreVisitor {
     pub no_timestamps: bool,
 
     /// whether to store additional metadata (like the etag) using extended attributes
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub no_xattrs: bool,
 }
 
@@ -40,7 +39,6 @@ impl StoreVisitor {
         Self {
             base: base.into(),
             no_timestamps: false,
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
             no_xattrs: false,
         }
     }
@@ -50,7 +48,6 @@ impl StoreVisitor {
         self
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn no_xattrs(mut self, no_xattrs: bool) -> Self {
         self.no_xattrs = no_xattrs;
         self
@@ -214,7 +211,6 @@ impl StoreVisitor {
                 sha512: &sbom.sha512,
                 signature: &sbom.signature,
                 no_timestamps: self.no_timestamps,
-                #[cfg(any(target_os = "linux", target_os = "macos"))]
                 no_xattrs: self.no_xattrs,
             },
         )


### PR DESCRIPTION
## Summary by Sourcery

Enable cross-platform etag attribute support by replacing xattr with fsquirrel and updating dependencies

New Features:
- Support storing and retrieving etag attributes on Windows

Enhancements:
- Replace xattr crate with fsquirrel for cross-platform extended attribute get/set
- Remove OS-specific cfg flags for etag handling

Chores:
- Add fsquirrel dependency across crates and remove xattr references
- Bump deno_core dependency to 0.353.0